### PR TITLE
set Encoding for process.stdout to correct for mangled umlaute in German

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,8 @@ return new Promise(function (resolve, reject) {
 }).then(function (db) {
   var dumpOpts = {};
   if (!split) {
+    // need to set encoding for process.stdout explicitly
+    // otherwise for instance German umlaute are mangled
     process.stdout.setEncoding('utf16le')
     var outstream = outfile ? fs.createWriteStream(outfile) : process.stdout;
     return db.dump(outstream, dumpOpts);

--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ return new Promise(function (resolve, reject) {
 }).then(function (db) {
   var dumpOpts = {};
   if (!split) {
+    process.stdout.setEncoding('utf16le')
     var outstream = outfile ? fs.createWriteStream(outfile) : process.stdout;
     return db.dump(outstream, dumpOpts);
   }


### PR DESCRIPTION
On Windows 8.1, in the output of

```
pouchdb-dump http://localhost:5984/ae_moose > ae_moose.txt
```

the German umlaute were mangled. For instance "ä" became "├ñ".

When using

```
pouchdb-dump http://localhost:5984/ae_moose -o ae_moose.txt
```

the output is correct.

So it seems that fs.createWriteStream uses utf16le encoding but process.stdout does not, unless it is explicitly told to.
