### PR TITLE
deps: Updates to latest dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
   },
   "homepage": "https://github.com/nolanlawson/pouchdb-dump-cli",
   "dependencies": {
-    "lie": "3.1.0",
-    "pouchdb-core": "^6.0.7",
-    "pouchdb-adapter-leveldb": "^6.0.7",
-    "pouchdb-adapter-http": "^6.0.7",
-    "pouchdb-replication": "^6.0.7",
+    "lie": "3.3.0",
+    "pouchdb-core": "7.2.1",
+    "pouchdb-adapter-leveldb": "7.2.1",
+    "pouchdb-adapter-http": "7.2.1",
+    "pouchdb-replication": "7.2.1",
     "pouchdb-replication-stream": "^1.2.6",
-    "progress": "1.1.8",
-    "through2": "0.6.5",
-    "yargs": "1.3.3"
+    "progress": "2.0.3",
+    "through2": "3.0.1",
+    "yargs": "15.3.1"
   }
 }


### PR DESCRIPTION
On OSX with NodeJS v13.6.0 there were symbol linking issues with the
dependencies.  By updating the dependencies symbol issues are resolved
and installation occurs without warning or issue.